### PR TITLE
[TASK] TYPO3 14 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
           - '8.1'
           - '8.2'
           - '8.3'
+          - '8.4'
     steps:
       -
         name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "typo3/cms-core": "^12.4 || ^13.4"
+        "typo3/cms-core": "^12.4 || ^13.4 || ^14.0"
     },
     "require-dev": {
         "mediatis/typo3-coding-standards": "^2.1.7 || ^3.0.3"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -7,10 +7,10 @@ $EM_CONF[$_EXTKEY] = [
     'author' => 'Meelis Karulin',
     'author_email' => 'info@mediatis.de',
     'state' => 'beta',
-    'version' => '1.0.3',
+    'version' => '1.1.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '12.4.0-13.4.99'
+            'typo3' => '12.4.0-14.4.99'
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
Bump typo3 constraint to 12.4-14.4.99. No PHP/runtime changes - TypoScript + JS only, forward-compatible with v14.